### PR TITLE
Linker tweaks

### DIFF
--- a/ed25519-donna/build.rs
+++ b/ed25519-donna/build.rs
@@ -566,6 +566,7 @@ fn main() {
         .include("/usr/include/openssl")
         .include("/usr/include")
         .include("ed25519-donna")
+        .define("ED25519_REFHASH", None)
         //.define("ED25519_INLINE_ASM", None)
         //.define("ED25519_CUSTOMHASH", None)
         //.define("ED25519_CUSTOMRANDOM", None)

--- a/ed25519-donna/src/ffi.rs
+++ b/ed25519-donna/src/ffi.rs
@@ -6,7 +6,7 @@
 
 use libc::{c_int, c_uchar, c_void, size_t};
 
-#[link(name = "ed25519_donna")]
+#[link(name = "ed25519donna")]
 extern "C" {
     fn ed25519_publickey(sk: *const c_uchar, pk: *mut c_uchar);
     fn ed25519_sign(m: *const c_uchar, mlen: size_t, sk: *const c_uchar, pk: *const c_uchar, RS: *mut c_uchar);


### PR DESCRIPTION
- ed25519-donna's Makefile produces "ed25519donna", not "ed25519_donna" as if it were a Rust package
- work around OpenSSL linking issues by using the reference hash